### PR TITLE
Add PIDA axis to PID Review tool

### DIFF
--- a/Libraries/OpenIn.js
+++ b/Libraries/OpenIn.js
@@ -21,7 +21,7 @@ function get_open_in(get_file_fun) {
     }
 
     function enable_pid_review(msgs) {
-        const pid_log = ["RATE", "PIDR", "PIDP", "PIDY", "PIQR", "PIQP", "PIQY"]
+        const pid_log = ["RATE", "PIDR", "PIDP", "PIDY", "PIQR", "PIQP", "PIQY", "PIDA"]
         return pid_log.some(item => msgs.includes(item));
     }
 

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -104,7 +104,7 @@ function reset() {
 
     document.title = "ArduPilot PID Review"
 
-    const types = ["PIDP",   "PIDR",   "PIDY",
+    const types = ["PIDP",   "PIDR",   "PIDY",   "PIDA",
                    "PIQP",   "PIQR",   "PIQY",
                    "RATE_R", "RATE_P", "RATE_Y"]
     for (const type of types) {
@@ -1381,6 +1381,7 @@ async function load(log_file) {
     PID_log_messages = [ {id: ["PIDR"],      prefixes: [ "ATC_RAT_RLL_", "RLL_RATE_"]},
                          {id: ["PIDP"],      prefixes: [ "ATC_RAT_PIT_", "PTCH_RATE_"]},
                          {id: ["PIDY"],      prefixes: [ "ATC_RAT_YAW_", "YAW_RATE_"]},
+                         {id: ["PIDA"],      prefixes: [ "PSC_ACCZ_",   "Q_P_ACCZ_" ]},
                          {id: ["PIQR"],      prefixes: [                 "Q_A_RAT_RLL_"]},
                          {id: ["PIQP"],      prefixes: [                 "Q_A_RAT_PIT_"]},
                          {id: ["PIQY"],      prefixes: [                 "Q_A_RAT_YAW_"]},
@@ -1499,13 +1500,13 @@ async function load(log_file) {
                                                                      Out: Array.from(log_msg[axis_prefix + "Out"].slice(batch.batch_start, batch.batch_end))})
 
                 } else {
-                    // Convert radians to degress
                     const rad2deg = 180.0 / Math.PI
+                    const scale = id === "PIDA" ? 1 : rad2deg
                     PID_log_messages[i].sets[batch.param_set].push({ time: time.slice(batch.batch_start, batch.batch_end),
                                                                      sample_rate: batch.sample_rate,
-                                                                     Tar: array_scale(Array.from(log_msg.Tar.slice(batch.batch_start, batch.batch_end)), rad2deg),
-                                                                     Act: array_scale(Array.from(log_msg.Act.slice(batch.batch_start, batch.batch_end)), rad2deg),
-                                                                     Err: array_scale(Array.from(log_msg.Err.slice(batch.batch_start, batch.batch_end)), rad2deg),
+                                                                     Tar: array_scale(Array.from(log_msg.Tar.slice(batch.batch_start, batch.batch_end)), scale),
+                                                                     Act: array_scale(Array.from(log_msg.Act.slice(batch.batch_start, batch.batch_end)), scale),
+                                                                     Err: array_scale(Array.from(log_msg.Err.slice(batch.batch_start, batch.batch_end)), scale),
                                                                      P:   Array.from(log_msg.P.slice(batch.batch_start, batch.batch_end)),
                                                                      I:   Array.from(log_msg.I.slice(batch.batch_start, batch.batch_end)),
                                                                      D:   Array.from(log_msg.D.slice(batch.batch_start, batch.batch_end)),

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -68,7 +68,7 @@
             </fieldset>
         </td>
         <td>
-            <fieldset style="width:300px;height:80px">
+            <fieldset style="width:300px;height:110px">
                 <legend>Axis</legend>
                 <table>
                     <td>
@@ -86,6 +86,8 @@
                         <label for="type_PIDP">PIDP</label><br>
                         <input type="radio" id="type_PIDY" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDY">PIDY</label><br>
+                        <input type="radio" id="type_PIDA" name="Axis" onchange="loading_call(setup_axis)">
+                        <label for="type_PIDA">PIDA</label><br>
                     </td>
                     <td>
                         <input type="radio" id="type_PIQR" name="Axis" onchange="loading_call(setup_axis)">


### PR DESCRIPTION
## Summary
- extend PID Review with a new PIDA axis option
- handle PIDA logs in javascript logic
- recognise PIDA logs for "Open In" links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68666231159c8329821b62db31270817