### PR TITLE
Add ToolHub, split modes and simplify PIDReview

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -44,6 +44,9 @@
 <table><tr><td style="width:1200px">
 <h1 style="text-align:center; margin-block-end: 0.25em;"><a href="" style="color: #000000; text-decoration:none;">ArduPilot Filter Review Tool</a></h1>
 </td></tr></table>
+<div style="text-align:center; margin-bottom:10px;">
+    <button onclick="history.back()">Back to Log Finder</button>
+</div>
 
 <body>
 

--- a/FilterReview/split.html
+++ b/FilterReview/split.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Filter Review Split</title>
+<style>
+  body { margin:0; display:flex; }
+  iframe { flex:1; border:none; height:100vh; }
+</style>
+</head>
+<body>
+<iframe src="index.html"></iframe>
+<iframe src="index.html"></iframe>
+</body>
+</html>

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -104,9 +104,7 @@ function reset() {
 
     document.title = "ArduPilot PID Review"
 
-    const types = ["PIDP",   "PIDR",   "PIDY",   "PIDA",
-                   "PIQP",   "PIQR",   "PIQY",
-                   "RATE_R", "RATE_P", "RATE_Y"]
+    const types = ["PIDP", "PIDR", "PIDY", "PIDA"]
     for (const type of types) {
         let ele = document.getElementById("type_" + type)
         ele.disabled = true
@@ -1517,16 +1515,10 @@ async function load(log_file) {
     reset()
 
     // Reset log object                                  Copter          Plane
-    PID_log_messages = [ {id: ["PIDR"],      prefixes: [ "ATC_RAT_RLL_", "RLL_RATE_"]},
-                         {id: ["PIDP"],      prefixes: [ "ATC_RAT_PIT_", "PTCH_RATE_"]},
-                         {id: ["PIDY"],      prefixes: [ "ATC_RAT_YAW_", "YAW_RATE_"]},
-                         {id: ["PIDA"],      prefixes: [ "PSC_ACCZ_",   "Q_P_ACCZ_" ]},
-                         {id: ["PIQR"],      prefixes: [                 "Q_A_RAT_RLL_"]},
-                         {id: ["PIQP"],      prefixes: [                 "Q_A_RAT_PIT_"]},
-                         {id: ["PIQY"],      prefixes: [                 "Q_A_RAT_YAW_"]},
-                         {id: ["RATE", "R"], prefixes: [ "ATC_RAT_RLL_", "Q_A_RAT_RLL_"]},
-                         {id: ["RATE", "P"], prefixes: [ "ATC_RAT_PIT_", "Q_A_RAT_PIT_"]},
-                         {id: ["RATE", "Y"], prefixes: [ "ATC_RAT_YAW_", "Q_A_RAT_YAW_"]} ]
+    PID_log_messages = [ {id: ["PIDR"], prefixes: [ "ATC_RAT_RLL_", "RLL_RATE_"]},
+                         {id: ["PIDP"], prefixes: [ "ATC_RAT_PIT_", "PTCH_RATE_"]},
+                         {id: ["PIDY"], prefixes: [ "ATC_RAT_YAW_", "YAW_RATE_"]},
+                         {id: ["PIDA"], prefixes: [ "PSC_ACCZ_", "Q_P_ACCZ_" ]} ]
 
     // Set flags for no data
     PID_log_messages.have_data = false

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -29,6 +29,9 @@
 <table><tr><td style="width:1200px">
 <h1 style="text-align:center"><a href="" style="color: #000000; text-decoration:none;">ArduPilot PID Review Tool</a></h1>
 </td></tr></table>
+<div style="text-align:center; margin-bottom:10px;">
+    <button onclick="history.back()">Back to Log Finder</button>
+</div>
 
 <body>
 
@@ -72,14 +75,6 @@
                 <legend>Axis</legend>
                 <table>
                     <td>
-                        <input type="radio" id="type_RATE_R" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_RATE_R">RATE Roll</label><br>
-                        <input type="radio" id="type_RATE_P" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_RATE_P">RATE Pitch</label><br>
-                        <input type="radio" id="type_RATE_Y" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_RATE_Y">RATE Yaw</label><br>
-                    </td>
-                    <td>
                         <input type="radio" id="type_PIDR" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDR">PIDR</label><br>
                         <input type="radio" id="type_PIDP" name="Axis" onchange="loading_call(setup_axis)">
@@ -88,14 +83,6 @@
                         <label for="type_PIDY">PIDY</label><br>
                         <input type="radio" id="type_PIDA" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDA">PIDA</label><br>
-                    </td>
-                    <td>
-                        <input type="radio" id="type_PIQR" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_PIQR">PIQR</label><br>
-                        <input type="radio" id="type_PIQP" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_PIQP">PIQP</label><br>
-                        <input type="radio" id="type_PIQY" name="Axis" onchange="loading_call(setup_axis)">
-                        <label for="type_PIQY">PIQY</label><br>
                     </td>
                 </table>
             </fieldset>

--- a/PIDReview/split.html
+++ b/PIDReview/split.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>PID Review Split</title>
+<style>
+  body { margin:0; display:flex; }
+  iframe { flex:1; border:none; height:100vh; }
+</style>
+</head>
+<body>
+<iframe src="index.html"></iframe>
+<iframe src="index.html"></iframe>
+</body>
+</html>

--- a/ToolHub/index.html
+++ b/ToolHub/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ArduPilot Tool Hub</title>
+<style>
+  body { margin:0; }
+  #toolbar { background:#eee; padding:10px; text-align:center; }
+  iframe { border:none; width:100%; height:calc(100vh - 50px); }
+  #split { display:flex; height:calc(100vh - 50px); }
+  #split iframe { flex:1; border:none; }
+</style>
+<script>
+function show(tool) {
+  var frame=document.getElementById('frame');
+  var split=document.getElementById('split');
+  if (tool==='FilterSplit') {
+    frame.style.display='none';
+    split.style.display='flex';
+    split.children[0].src='../FilterReview/index.html';
+    split.children[1].src='../FilterReview/index.html';
+  } else if (tool==='PIDSplit') {
+    frame.style.display='none';
+    split.style.display='flex';
+    split.children[0].src='../PIDReview/index.html';
+    split.children[1].src='../PIDReview/index.html';
+  } else {
+    split.style.display='none';
+    frame.style.display='block';
+    frame.src='../'+tool+'/index.html';
+  }
+}
+</script>
+</head>
+<body onload="show('LogFinder')">
+<div id="toolbar">
+<button onclick="show('LogFinder')">Log Finder</button>
+<button onclick="show('FilterReview')">Filter Review</button>
+<button onclick="show('PIDReview')">PID Review</button>
+<button onclick="show('FilterSplit')">Filter Review Split</button>
+<button onclick="show('PIDSplit')">PID Review Split</button>
+</div>
+<iframe id="frame"></iframe>
+<div id="split" style="display:none">
+  <iframe></iframe>
+  <iframe></iframe>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new ToolHub page to host LogFinder, FilterReview and PIDReview
- allow split screen versions of FilterReview and PIDReview
- trim PIDReview axis options and add back buttons
- add back buttons for FilterReview

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f8d0779348329b6b931afa6183fcf