### PR TITLE
Fix open in hub navigation

### DIFF
--- a/Libraries/OpenIn.js
+++ b/Libraries/OpenIn.js
@@ -64,6 +64,13 @@ function get_open_in(get_file_fun) {
             }
 
             if (dest.hook_load) {
+                // If running inside the Tool Hub pass request to parent so the
+                // new tool opens in the same hub tab
+                if (window.parent !== window) {
+                    window.parent.postMessage({ type: 'openInHub', path: dest.path, file }, '*')
+                    return
+                }
+
                 // Open the new page and keep a reference to it
                 const newWindow = window.open(dest.path)
 

--- a/ToolHub/index.html
+++ b/ToolHub/index.html
@@ -30,6 +30,20 @@ function show(tool) {
     frame.src='../'+tool+'/index.html';
   }
 }
+
+// Listen for "open in" requests from tools loaded in the iframe
+window.addEventListener('message', function(e) {
+  if (e.data.type === 'openInHub') {
+    var frame=document.getElementById('frame');
+    var split=document.getElementById('split');
+    split.style.display='none';
+    frame.style.display='block';
+    frame.src=e.data.path;
+    frame.onload=function() {
+      frame.contentWindow.postMessage({ type:'file', data:e.data.file }, '*');
+    };
+  }
+});
 </script>
 </head>
 <body onload="show('LogFinder')">


### PR DESCRIPTION
## Summary
- open selected logs in the same Tool Hub tab
- forward "open in" requests from iframe back to Tool Hub

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f9102f3a48329bb1ab4e82fa831e4