### PR TITLE
Fix Firebase action submodules

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,15 @@ You need to keep your submodules update. When you rebase, or switch branches, up
 git submodule update --init --recursive
 ```
 
+If deploying via CI (for example using the provided GitHub Actions workflows),
+ensure the checkout step fetches submodules:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    submodules: recursive
+```
+
 ## VSCode
 
 This repository contains VSCode launch configurations for debugging with Chrome and Edge. WebTools are either hosted with python as above or using the [LiveServer extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) which enables auto-reload. More information on debugging with VSCode [here](https://code.visualstudio.com/docs/editor/debugging).


### PR DESCRIPTION
## Summary
- ensure GitHub Actions fetch submodules for Firebase deploys
- document submodule checkout requirement for CI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f99d5112883298656d258c428b2fa