### PR TITLE
Add value display toggles to PID Review charts

### DIFF
--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -896,9 +896,10 @@ function redraw() {
     const axis_id = PID_log_messages[get_axis_index()].id
     const axis_letter = axis_id.length > 1 ? axis_id[1] : axis_id[0].slice(-1)
 
-    document.getElementById("AttPlot").style.display = axis_letter === 'A' ? 'none' : 'block'
-    if (document.getElementById("AltPlot")) {
-        document.getElementById("AltPlot").style.display = axis_letter === 'A' ? 'block' : 'none'
+    document.getElementById("AttPlot_container").style.display = axis_letter === 'A' ? 'none' : 'flex'
+    const alt_container = document.getElementById("AltPlot_container")
+    if (alt_container) {
+        alt_container.style.display = axis_letter === 'A' ? 'flex' : 'none'
     }
 
     if (axis_letter !== 'A' && Attitude.time != null) {
@@ -1753,6 +1754,18 @@ async function load(log_file) {
 
     const end = performance.now();
     console.log(`Load took: ${end - start} ms`);
+}
+
+function toggle_plot_values(id) {
+    const show = document.getElementById(id + 'Values').checked;
+    const plot = document.getElementById(id);
+    if (!plot || !plot.data) {
+        return;
+    }
+    for (let i = 0; i < plot.data.length; i++) {
+        const text = show ? plot.data[i].y : null;
+        Plotly.restyle(plot, {text: [text], textposition: show ? 'top left' : null}, [i]);
+    }
 }
 
 // Setup the selected axis

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -97,22 +97,47 @@
     <h2 style="text-align:center">Flight Data</h2>
 </td></tr></table>
 
-<div id="FlightData" style="width:1200px;height:450px"></div>
+<div id="FlightData_container" style="display:flex;align-items:flex-start">
+    <div id="FlightData" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="FlightDataValues" onchange="toggle_plot_values('FlightData')">Show values</label>
+    </div>
+</div>
 
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Time domain</h2>
 </td></tr></table>
 
-<div id="TimeInputs" style="width:1200px;height:450px"></div>
-<div id="TimeOutputs" style="width:1200px;height:450px"></div>
+<div id="TimeInputs_container" style="display:flex;align-items:flex-start">
+    <div id="TimeInputs" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="TimeInputsValues" onchange="toggle_plot_values('TimeInputs')">Show values</label>
+    </div>
+</div>
+<div id="TimeOutputs_container" style="display:flex;align-items:flex-start">
+    <div id="TimeOutputs" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="TimeOutputsValues" onchange="toggle_plot_values('TimeOutputs')">Show values</label>
+    </div>
+</div>
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Attitude Desired vs Actual</h2>
 </td></tr></table>
-<div id="AttPlot" style="width:1200px;height:450px"></div>
+<div id="AttPlot_container" style="display:flex;align-items:flex-start">
+    <div id="AttPlot" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="AttPlotValues" onchange="toggle_plot_values('AttPlot')">Show values</label>
+    </div>
+</div>
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Altitude Desired vs Actual</h2>
 </td></tr></table>
-<div id="AltPlot" style="width:1200px;height:450px;display:none"></div>
+<div id="AltPlot_container" style="display:none;align-items:flex-start">
+    <div id="AltPlot" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="AltPlotValues" onchange="toggle_plot_values('AltPlot')">Show values</label>
+    </div>
+</div>
 
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Frequency domain</h2>
@@ -175,7 +200,12 @@
     </tr>
 </table>
 
-<div id="FFTPlot" style="width:1200px;height:450px"></div>
+<div id="FFTPlot_container" style="display:flex;align-items:flex-start">
+    <div id="FFTPlot" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="FFTPlotValues" onchange="toggle_plot_values('FFTPlot')">Show values</label>
+    </div>
+</div>
 
 <table>
     <td style="width: 250px;"></td>
@@ -210,13 +240,23 @@
     <h2 style="text-align:center">Step Response</h2>
 </td></tr></table>
 
-<div id="step_plot" style="width:1200px;height:450px"></div>
+<div id="step_plot_container" style="display:flex;align-items:flex-start">
+    <div id="step_plot" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="step_plotValues" onchange="toggle_plot_values('step_plot')">Show values</label>
+    </div>
+</div>
 
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">PID Spectrogram</h2>
 </td></tr></table>
 
-<div id="Spectrogram" style="width:1200px;height:450px"></div>
+<div id="Spectrogram_container" style="display:flex;align-items:flex-start">
+    <div id="Spectrogram" style="width:1200px;height:450px"></div>
+    <div style="margin-left:10px;">
+        <label><input type="checkbox" id="SpectrogramValues" onchange="toggle_plot_values('Spectrogram')">Show values</label>
+    </div>
+</div>
 
 <table>
     <td style="width: 375px;"></td>


### PR DESCRIPTION
## Summary
- add side checkboxes beside every PID Review plot to show or hide numeric values
- expose a `toggle_plot_values` helper that restyles Plotly traces
- update attitude/altitude plot switching to account for new plot containers

## Testing
- `node --check PIDReview/PIDReview.js`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893432d70b08329a305890802edbc14