### PR TITLE
Add rate output and error plots to PID review

### DIFF
--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -114,6 +114,14 @@
     <div id="TimeOutputs" style="width:1200px;height:450px"></div>
     <div id="TimeOutputs_visibility" style="margin-left:10px;"></div>
 </div>
+<div id="RateOutput_container" style="display:flex;align-items:flex-start">
+    <div id="RateOutput" style="width:1200px;height:450px"></div>
+    <div id="RateOutput_visibility" style="margin-left:10px;"></div>
+</div>
+<div id="RateDiff_container" style="display:flex;align-items:flex-start">
+    <div id="RateDiff" style="width:1200px;height:450px"></div>
+    <div id="RateDiff_visibility" style="margin-left:10px;"></div>
+</div>
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Attitude Desired vs Actual</h2>
 </td></tr></table>


### PR DESCRIPTION
## Summary
- show dedicated RATE output plot with dashed limit line at 20 for all axes
- add RATE tracking error graph plotting actual minus desired rates

## Testing
- `node --check PIDReview/PIDReview.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896650be8948329bca9abcc6225e098