### PR TITLE
Add Params Compare Tool

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -39,6 +39,7 @@
 </td></tr></table>
 <div style="text-align:center; margin-bottom:10px;">
     <button onclick="history.back()">Back to Log Finder</button>
+    <button onclick="window.location.href='../ParamsCompare/index.html'">Params Compare</button>
 </div>
 
 <body>

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -24,6 +24,7 @@
 </td></tr></table>
 <div style="text-align:center; margin-bottom:10px;">
     <button onclick="history.back()">Back to Log Finder</button>
+    <button onclick="window.location.href='../ParamsCompare/index.html'">Params Compare</button>
 </div>
 
 <body>

--- a/ParamsCompare/ParamsCompare.js
+++ b/ParamsCompare/ParamsCompare.js
@@ -1,0 +1,79 @@
+var DataflashParser;
+const import_done = import('../modules/JsDataflashParser/parser.js').then(mod => { DataflashParser = mod.default });
+
+let paramsA = {};
+let paramsB = {};
+
+async function readFile(input, side) {
+    const file = input.files[0];
+    if (!file) { return; }
+    if (file.name.toLowerCase().endsWith('.bin')) {
+        await import_done;
+        const buffer = await file.arrayBuffer();
+        let log = new DataflashParser();
+        log.processData(buffer, []);
+        if (!("PARM" in log.messageTypes)) {
+            alert("No params in log");
+            return;
+        }
+        const PARM = log.get("PARM");
+        let params = {};
+        for (let i = 0; i < PARM.Name.length; i++) {
+            params[PARM.Name[i]] = PARM.Value[i];
+        }
+        setParams(side, params);
+    } else {
+        const text = await file.text();
+        document.getElementById(side === 'A' ? 'textA' : 'textB').value = text;
+        setParams(side, parseParamText(text));
+    }
+    updateDiff();
+}
+
+function readText(text, side) {
+    setParams(side, parseParamText(text));
+    updateDiff();
+}
+
+function setParams(side, params) {
+    if (side === 'A') {
+        paramsA = params;
+    } else {
+        paramsB = params;
+    }
+}
+
+function parseParamText(text) {
+    const params = {};
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+        const parts = line.trim().split(/[\s,=\t,]+/);
+        if (parts.length >= 2) {
+            const value = parseFloat(parts[1]);
+            if (!isNaN(value)) {
+                params[parts[0]] = value;
+            }
+        }
+    }
+    return params;
+}
+
+function updateDiff() {
+    const tbody = document.getElementById('diff');
+    tbody.innerHTML = '';
+    const keys = new Set([...Object.keys(paramsA), ...Object.keys(paramsB)]);
+    const sorted = Array.from(keys).sort((a, b) => a.localeCompare(b));
+    for (const key of sorted) {
+        const valA = paramsA[key];
+        const valB = paramsB[key];
+        const tr = document.createElement('tr');
+        if (valA !== valB) {
+            tr.style.backgroundColor = '#ffdddd';
+        }
+        const valAstr = valA === undefined ? '' : param_to_string(valA);
+        const valBstr = valB === undefined ? '' : param_to_string(valB);
+        tr.innerHTML = `<td style="padding:2px 6px;">${key}</td><td style="padding:2px 6px;">${valAstr}</td><td style="padding:2px 6px;">${valBstr}</td>`;
+        tbody.appendChild(tr);
+    }
+}
+

--- a/ParamsCompare/Readme.md
+++ b/ParamsCompare/Readme.md
@@ -1,0 +1,3 @@
+# Param Compare Tool
+
+Compare ArduPilot parameter sets from log or `.params` files. Load two files or paste parameter text to visualise differences.

--- a/ParamsCompare/index.html
+++ b/ParamsCompare/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Param Compare Tool</title>
+<link rel="icon" href="../images/AP_favicon.png">
+<script type="text/javascript" src="ParamsCompare.js" defer></script>
+<script type="text/javascript" src="../Libraries/Param_Helpers.js" defer></script>
+</head>
+<body>
+<table><tr><td style="width:1200px">
+<h1 style="text-align:center"><a href="" style="color: #000000; text-decoration:none;">ArduPilot Param Compare Tool</a></h1>
+</td></tr></table>
+<div style="text-align:center; margin-bottom:10px;">
+    <button onclick="history.back()">Back to Log Finder</button>
+</div>
+
+<div style="display:flex; gap:20px; justify-content:center;">
+  <div>
+    <h3>First Params</h3>
+    <input type="file" accept=".bin,.params" onchange="readFile(this, 'A')"><br>
+    <textarea id="textA" rows="10" cols="40" placeholder="Paste params here" oninput="readText(this.value, 'A')"></textarea>
+  </div>
+  <div>
+    <h3>Second Params</h3>
+    <input type="file" accept=".bin,.params" onchange="readFile(this, 'B')"><br>
+    <textarea id="textB" rows="10" cols="40" placeholder="Paste params here" oninput="readText(this.value, 'B')"></textarea>
+  </div>
+</div>
+
+<h2 style="text-align:center">Differences</h2>
+<table id="diffTable" style="margin:auto; border-collapse:collapse;">
+  <thead>
+    <tr><th style="padding:4px;">Param</th><th style="padding:4px;">First</th><th style="padding:4px;">Second</th></tr>
+  </thead>
+  <tbody id="diff"></tbody>
+</table>
+</body>
+</html>

--- a/ToolHub/index.html
+++ b/ToolHub/index.html
@@ -51,6 +51,7 @@ window.addEventListener('message', function(e) {
 <button onclick="show('LogFinder')">Log Finder</button>
 <button onclick="show('FilterReview')">Filter Review</button>
 <button onclick="show('PIDReview')">PID Review</button>
+<button onclick="show('ParamsCompare')">Params Compare</button>
 <button onclick="show('FilterSplit')">Filter Review Split</button>
 <button onclick="show('PIDSplit')">PID Review Split</button>
 </div>


### PR DESCRIPTION
## Summary
- add PARAMS Compare Tool for visualising differences between parameter files
- link Params Compare from PID Review and Filter Review headers
- expose Params Compare in Tool Hub navigation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d5b81a58832981e35d83a109bc5b